### PR TITLE
fix: await async config functions in array for reduceConfigsAsyncWithContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,11 +139,16 @@ export async function reduceConfigsAsyncWithContext<T, Ctx>({
     return (await config(initial, ctx)) ?? initial;
   }
   if (Array.isArray(config)) {
-    return config.reduce(
-      (initial, config) =>
-        reduceConfigsWithContext({ initial, config, ctx, mergeFn }),
-      initial,
-    );
+    let result = initial;
+    for (const item of config) {
+      result = await reduceConfigsAsyncWithContext({
+        initial: result,
+        config: item,
+        ctx,
+        mergeFn,
+      });
+    }
+    return result;
   }
   return config ?? initial;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 import { assert, test } from '@rstest/core';
 import {
   reduceConfigs,
+  reduceConfigsAsyncWithContext,
   reduceConfigsMergeContext,
   reduceConfigsWithContext,
 } from '../dist/index.js';
@@ -123,6 +124,68 @@ test('reduceConfigs should support function and merge context', () => {
       d: 'd',
       e: 'e',
     },
+  );
+});
+
+test('reduceConfigsAsyncWithContext should support async functions in array', async () => {
+  const initial = { a: 'a' };
+
+  const config = [
+    { b: 'b' },
+    async (o, { add }) => {
+      o.c = await add(1, 2);
+    },
+    (o) => ({
+      ...o,
+      d: 'd',
+    }),
+    { e: 'e' },
+  ];
+
+  assert.deepStrictEqual(
+    await reduceConfigsAsyncWithContext({
+      initial,
+      config,
+      ctx: {
+        add: async (a, b) => a + b,
+      },
+    }),
+    {
+      a: 'a',
+      b: 'b',
+      c: 3,
+      d: 'd',
+      e: 'e',
+    },
+  );
+});
+
+test('reduceConfigsAsyncWithContext should support multiple async functions in array', async () => {
+  const initial = { value: 1 };
+
+  const config = [
+    async (o) => ({ ...o, value: o.value + 10 }),
+    async (o) => ({ ...o, value: o.value * 2 }),
+  ];
+
+  assert.deepStrictEqual(
+    await reduceConfigsAsyncWithContext({
+      initial,
+      config,
+    }),
+    { value: 22 },
+  );
+});
+
+test('reduceConfigsAsyncWithContext should handle single async function', async () => {
+  const initial = { a: 1 };
+
+  assert.deepStrictEqual(
+    await reduceConfigsAsyncWithContext({
+      initial,
+      config: async (o) => ({ ...o, b: 2 }),
+    }),
+    { a: 1, b: 2 },
   );
 });
 


### PR DESCRIPTION
## Summary

When `config` is an array containing async functions, `reduceConfigsAsyncWithContext` does not `await` them — the Promise object leaks into the next reducer iteration as-is:

```js
await reduceConfigsAsyncWithContext({
  initial: { a: 1 },
  config: [
    async (cfg) => ({ ...cfg, b: 2 }),  // returns a Promise, never awaited
    (cfg) => ({ ...cfg, c: 3 }),         // receives Promise instead of object
  ],
})
```

In Rsbuild, this surfaces when multiple `tools.rspack` functions (some async) are merged via `mergeRsbuildConfig` into an array, then processed by this function — `webpack-merge` receives a Promise and throws:

```
TypeError: Promises are not supported
    at mergeWithOptions (webpack-merge/index.js:513:19)
```

This PR fixes the issue.

Related: https://github.com/rstackjs/storybook-rsbuild/issues/255

## Test plan

- [x] Added 3 test cases for `reduceConfigsAsyncWithContext`
- [x] All existing tests still pass
- [x] `pnpm lint` and `pnpm build && pnpm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)