### PR TITLE
feat!: make config reducers async

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ npm add reduce-configs -D
 
 ## reduceConfigs
 
-The `reduceConfigs` function merges one or more configuration objects into a final configuration. It also allows modification of the configuration object via functions.
+The `reduceConfigs` function merges one or more configuration objects into a final configuration. It also allows modifying the configuration object via functions that may be async.
 
 - **Type:**
 
 ```ts
 type OneOrMany<T> = T | T[];
-type ConfigChain<T> = OneOrMany<T | ((config: T) => T | void)>;
+type MaybePromise<T> = T | Promise<T>;
+
+type ConfigChain<T> = OneOrMany<T | ((config: T) => MaybePromise<T | void>)>;
 
 function reduceConfigs<T>(options: {
   /**
@@ -32,7 +34,7 @@ function reduceConfigs<T>(options: {
   initial: T;
   /**
    * The configuration object, function, or array of configuration objects/functions
-   * to be merged into the initial configuration
+   * to be merged into the initial configuration.
    */
   config?: ConfigChain<T> | undefined;
   /**
@@ -40,52 +42,61 @@ function reduceConfigs<T>(options: {
    * @default Object.assign
    */
   mergeFn?: typeof Object.assign;
-}): T;
+}): Promise<T>;
 ```
 
 - **Example:**
 
 ```ts
-import { reduceConfigs } from '@rsbuild/core';
+import { reduceConfigs } from 'reduce-configs';
 
 const initial = { a: 1, b: 2 };
 
 // Merging an object
-const finalConfig1 = reduceConfigs({
-  initial: initial,
+const finalConfig1 = await reduceConfigs({
+  initial,
   config: { b: 3, c: 4 },
 });
 // -> { a: 1, b: 3, c: 4 }
 
 // Using a function to modify the config
-const finalConfig2 = reduceConfigs({
-  initial: initial,
+const finalConfig2 = await reduceConfigs({
+  initial,
   config: (config) => ({ ...config, b: 5, d: 6 }),
 });
 // -> { a: 1, b: 5, d: 6 }
 
+// Using a function that returns a Promise
+const finalConfig3 = await reduceConfigs({
+  initial,
+  config: async (config) => ({ ...config, c: await loadValue() }),
+});
+// -> { a: 1, b: 2, c: ... }
+
 // Merging an array of objects/functions
-const finalConfig3 = reduceConfigs({
-  initial: initial,
+const finalConfig4 = await reduceConfigs({
+  initial,
   config: [
     { b: 7 },
     (config) => ({ ...config, c: 8 }),
-    (config) => ({ ...config, d: 9 }),
+    async (config) => ({ ...config, d: await loadValue() }),
   ],
 });
-// -> { a: 1, b: 7, c: 8, d: 9 }
+// -> { a: 1, b: 7, c: 8, d: ... }
 ```
 
 ## reduceConfigsWithContext
 
-The `reduceConfigsWithContext` function is similar to `reduceConfigs`, which allows you to pass an additional `context` object to the configuration function.
+The `reduceConfigsWithContext` function is similar to `reduceConfigs`, and passes an additional `context` object to each configuration function.
 
 - **Type:**
 
 ```ts
 type OneOrMany<T> = T | T[];
+type MaybePromise<T> = T | Promise<T>;
+
 type ConfigChainWithContext<T, Ctx> = OneOrMany<
-  T | ((config: T, ctx: Ctx) => T | void)
+  T | ((config: T, ctx: Ctx) => MaybePromise<T | void>)
 >;
 
 function reduceConfigsWithContext<T, Ctx>(options: {
@@ -95,9 +106,9 @@ function reduceConfigsWithContext<T, Ctx>(options: {
   initial: T;
   /**
    * The configuration object, function, or array of configuration objects/functions
-   * to be merged into the initial configuration
+   * to be merged into the initial configuration.
    */
-  config?: ConfigChain<T> | undefined;
+  config?: ConfigChainWithContext<T, Ctx> | undefined;
   /**
    * Context object that can be used within the configuration functions.
    */
@@ -107,26 +118,82 @@ function reduceConfigsWithContext<T, Ctx>(options: {
    * @default Object.assign
    */
   mergeFn?: typeof Object.assign;
-}): T;
+}): Promise<T>;
 ```
 
 - **Example:**
 
 ```ts
-import { reduceConfigsWithContext } from '@rsbuild/core';
+import { reduceConfigsWithContext } from 'reduce-configs';
 
 const initial = { a: 1, b: 2 };
 const context = { user: 'admin' };
 
-const finalConfig = reduceConfigsWithContext({
+const finalConfig = await reduceConfigsWithContext({
   initial,
   config: [
     { b: 3 },
     (config, ctx) => ({ ...config, c: ctx.user === 'admin' ? 99 : 4 }),
+    async (config, ctx) => ({ ...config, d: await loadValue(ctx.user) }),
   ],
   ctx: context,
 });
-// -> { a: 1, b: 3, c: 99 }
+// -> { a: 1, b: 3, c: 99, d: ... }
+```
+
+## reduceConfigsWithMergedContext
+
+The `reduceConfigsWithMergedContext` function passes a single merged object to each configuration function. The object contains the current value under `value`, plus all fields from `ctx`.
+
+- **Type:**
+
+```ts
+type OneOrMany<T> = T | T[];
+type MaybePromise<T> = T | Promise<T>;
+
+type ConfigChainWithMergedContext<T, Ctx> = OneOrMany<
+  T | ((merged: { value: T } & Ctx) => MaybePromise<T | void>)
+>;
+
+function reduceConfigsWithMergedContext<T, Ctx>(options: {
+  /**
+   * Initial configuration object.
+   */
+  initial: T;
+  /**
+   * The configuration object, function, or array of configuration objects/functions
+   * to be merged into the initial configuration.
+   */
+  config?: ConfigChainWithMergedContext<T, Ctx> | undefined;
+  /**
+   * Context object that will be merged with the current value and passed to configuration functions.
+   */
+  ctx?: Ctx;
+  /**
+   * The function used to merge configuration objects.
+   * @default Object.assign
+   */
+  mergeFn?: typeof Object.assign;
+}): Promise<T>;
+```
+
+- **Example:**
+
+```ts
+import { reduceConfigsWithMergedContext } from 'reduce-configs';
+
+const initial = './index.html';
+const context = { entryName: 'admin' };
+
+const template = await reduceConfigsWithMergedContext({
+  initial,
+  config: async ({ value, entryName }) => {
+    const templates = await loadTemplates();
+    return templates[entryName] || value;
+  },
+  ctx: context,
+});
+// -> './admin.html'
 ```
 
 ## License

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
 type OneOrMany<T> = T | T[];
 type MaybePromise<T> = T | Promise<T>;
 
-export type ConfigChain<T> = OneOrMany<T | ((config: T) => T | void)>;
-export type ConfigChainWithContext<T, Ctx> = OneOrMany<
-  T | ((config: T, ctx: Ctx) => T | void)
+export type ConfigChain<T> = OneOrMany<
+  T | ((config: T) => MaybePromise<T | void>)
 >;
-export type ConfigChainAsyncWithContext<T, Ctx> = OneOrMany<
+
+export type ConfigChainWithContext<T, Ctx> = OneOrMany<
   T | ((config: T, ctx: Ctx) => MaybePromise<T | void>)
 >;
-export type ConfigChainMergeContext<T, Ctx> = OneOrMany<
-  T | ((merged: { value: T } & Ctx) => T | void)
+
+export type ConfigChainWithMergedContext<T, Ctx> = OneOrMany<
+  T | ((merged: { value: T } & Ctx) => MaybePromise<T | void>)
 >;
 
 const isNil = (o: unknown): o is undefined | null =>
@@ -26,9 +27,9 @@ const isPlainObject = (obj: unknown): obj is Record<string, any> =>
 
 /**
  * Merge one or more configs into a final config,
- * and allow to modify the config object via a function.
+ * and allow modifying the config object via a function that may be async.
  */
-export function reduceConfigs<T>({
+export async function reduceConfigs<T>({
   initial,
   config,
   mergeFn = Object.assign,
@@ -39,7 +40,7 @@ export function reduceConfigs<T>({
   initial: T;
   /**
    * The configuration object, function, or array of configuration objects/functions
-   * to be merged into the initial configuration
+   * to be merged into the initial configuration.
    */
   config?: ConfigChain<T> | undefined;
   /**
@@ -47,7 +48,7 @@ export function reduceConfigs<T>({
    * @default Object.assign
    */
   mergeFn?: typeof Object.assign;
-}): T {
+}): Promise<T> {
   if (isNil(config)) {
     return initial;
   }
@@ -55,22 +56,23 @@ export function reduceConfigs<T>({
     return isPlainObject(initial) ? mergeFn(initial, config) : (config as T);
   }
   if (isFunction(config)) {
-    return config(initial) ?? initial;
+    return (await config(initial)) ?? initial;
   }
   if (Array.isArray(config)) {
-    return config.reduce(
-      (initial, config) => reduceConfigs({ initial, config, mergeFn }),
-      initial,
-    );
+    let result = initial;
+    for (const item of config) {
+      result = await reduceConfigs({ initial: result, config: item, mergeFn });
+    }
+    return result;
   }
   return config ?? initial;
 }
 
 /**
  * Merge one or more configs into a final config,
- * and allow to modify the config object via a function, the function accepts a context object.
+ * and allow modifying the config object via a function that may be async and accepts a context object.
  */
-export function reduceConfigsWithContext<T, Ctx>({
+export async function reduceConfigsWithContext<T, Ctx>({
   initial,
   config,
   ctx,
@@ -82,7 +84,7 @@ export function reduceConfigsWithContext<T, Ctx>({
   initial: T;
   /**
    * The configuration object, function, or array of configuration objects/functions
-   * to be merged into the initial configuration
+   * to be merged into the initial configuration.
    */
   config?: ConfigChainWithContext<T, Ctx> | undefined;
   /**
@@ -93,40 +95,6 @@ export function reduceConfigsWithContext<T, Ctx>({
    * The function used to merge configuration objects.
    * @default Object.assign
    */
-  mergeFn?: typeof Object.assign;
-}): T {
-  if (isNil(config)) {
-    return initial;
-  }
-  if (isPlainObject(config)) {
-    return isPlainObject(initial) ? mergeFn(initial, config) : (config as T);
-  }
-  if (isFunction(config)) {
-    return config(initial, ctx) ?? initial;
-  }
-  if (Array.isArray(config)) {
-    return config.reduce(
-      (initial, config) =>
-        reduceConfigsWithContext({ initial, config, ctx, mergeFn }),
-      initial,
-    );
-  }
-  return config ?? initial;
-}
-
-/**
- * Merge one or more configs into a final config,
- * and allow to modify the config object via an async function, the function accepts a context object.
- */
-export async function reduceConfigsAsyncWithContext<T, Ctx>({
-  initial,
-  config,
-  ctx,
-  mergeFn = Object.assign,
-}: {
-  initial: T;
-  config?: ConfigChainAsyncWithContext<T, Ctx> | undefined;
-  ctx?: Ctx;
   mergeFn?: typeof Object.assign;
 }): Promise<T> {
   if (isNil(config)) {
@@ -141,7 +109,7 @@ export async function reduceConfigsAsyncWithContext<T, Ctx>({
   if (Array.isArray(config)) {
     let result = initial;
     for (const item of config) {
-      result = await reduceConfigsAsyncWithContext({
+      result = await reduceConfigsWithContext({
         initial: result,
         config: item,
         ctx,
@@ -155,19 +123,33 @@ export async function reduceConfigsAsyncWithContext<T, Ctx>({
 
 /**
  * Merge one or more configs into a final config,
- * and allow to modify the config object via an async function, the function accepts a merged object.
+ * and allow modifying the config object via a function that may be async and accepts a merged context object.
  */
-export function reduceConfigsMergeContext<T, Ctx>({
+export async function reduceConfigsWithMergedContext<T, Ctx>({
   initial,
   config,
   ctx,
   mergeFn = Object.assign,
 }: {
+  /**
+   * Initial configuration object.
+   */
   initial: T;
-  config?: ConfigChainMergeContext<T, Ctx> | undefined;
+  /**
+   * The configuration object, function, or array of configuration objects/functions
+   * to be merged into the initial configuration.
+   */
+  config?: ConfigChainWithMergedContext<T, Ctx> | undefined;
+  /**
+   * Context object that will be merged with the current value and passed to configuration functions.
+   */
   ctx?: Ctx;
+  /**
+   * The function used to merge configuration objects.
+   * @default Object.assign
+   */
   mergeFn?: typeof Object.assign;
-}): T {
+}): Promise<T> {
   if (isNil(config)) {
     return initial;
   }
@@ -175,19 +157,19 @@ export function reduceConfigsMergeContext<T, Ctx>({
     return isPlainObject(initial) ? mergeFn(initial, config) : (config as T);
   }
   if (isFunction(config)) {
-    return config({ value: initial, ...ctx }) ?? initial;
+    return (await config({ value: initial, ...ctx })) ?? initial;
   }
   if (Array.isArray(config)) {
-    return config.reduce(
-      (initial, config) =>
-        reduceConfigsMergeContext({
-          initial,
-          config,
-          ctx,
-          mergeFn,
-        }),
-      initial,
-    );
+    let result = initial;
+    for (const item of config) {
+      result = await reduceConfigsWithMergedContext({
+        initial: result,
+        config: item,
+        ctx,
+        mergeFn,
+      });
+    }
+    return result;
   }
   return config ?? initial;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,20 +1,34 @@
 import { assert, test } from '@rstest/core';
 import {
   reduceConfigs,
-  reduceConfigsAsyncWithContext,
-  reduceConfigsMergeContext,
   reduceConfigsWithContext,
+  reduceConfigsWithMergedContext,
 } from '../dist/index.js';
 
-test('reduceConfigs should return initial config', () => {
-  assert.deepStrictEqual(reduceConfigs({ initial: { value: 'a' } }), {
+test('all reducers should return promises', () => {
+  assert.strictEqual(
+    typeof reduceConfigs({ initial: { value: 'a' } }).then,
+    'function',
+  );
+  assert.strictEqual(
+    typeof reduceConfigsWithContext({ initial: { value: 'a' } }).then,
+    'function',
+  );
+  assert.strictEqual(
+    typeof reduceConfigsWithMergedContext({ initial: { value: 'a' } }).then,
+    'function',
+  );
+});
+
+test('reduceConfigs should return initial config', async () => {
+  assert.deepStrictEqual(await reduceConfigs({ initial: { value: 'a' } }), {
     value: 'a',
   });
 });
 
-test('reduceConfigs should merge initial config', () => {
+test('reduceConfigs should merge initial config', async () => {
   assert.deepStrictEqual(
-    reduceConfigs({
+    await reduceConfigs({
       initial: { name: 'a' },
       config: {
         name: 'b',
@@ -28,7 +42,7 @@ test('reduceConfigs should merge initial config', () => {
   );
 });
 
-test('reduceConfigs should support custom merge function', () => {
+test('reduceConfigs should support custom merge function', async () => {
   const merge = (target, source) => {
     for (const key in source) {
       if (Object.hasOwn(target, key)) {
@@ -41,7 +55,7 @@ test('reduceConfigs should support custom merge function', () => {
   };
 
   assert.deepStrictEqual(
-    reduceConfigs({
+    await reduceConfigs({
       initial: {
         a: 1,
         b: 'b',
@@ -61,15 +75,15 @@ test('reduceConfigs should support custom merge function', () => {
   );
 });
 
-test('reduceConfigs should support function or object array', () => {
+test('reduceConfigs should support function or object array', async () => {
   const initial = { a: 'a' };
 
   const config = [
     { b: 'b' },
-    (o, { add }) => {
-      o.c = add(1, 2);
+    (o) => {
+      o.c = 3;
     },
-    (o) => ({
+    async (o) => ({
       ...o,
       d: 'd',
     }),
@@ -77,12 +91,9 @@ test('reduceConfigs should support function or object array', () => {
   ];
 
   assert.deepStrictEqual(
-    reduceConfigsWithContext({
+    await reduceConfigs({
       initial,
       config,
-      ctx: {
-        add: (a, b) => a + b,
-      },
     }),
     {
       a: 'a',
@@ -94,40 +105,7 @@ test('reduceConfigs should support function or object array', () => {
   );
 });
 
-test('reduceConfigs should support function and merge context', () => {
-  const initial = { a: 'a' };
-
-  const config = [
-    { b: 'b' },
-    ({ value, add }) => {
-      value.c = add(1, 2);
-    },
-    ({ value }) => ({
-      ...value,
-      d: 'd',
-    }),
-    { e: 'e' },
-  ];
-
-  assert.deepStrictEqual(
-    reduceConfigsMergeContext({
-      initial,
-      config,
-      ctx: {
-        add: (a, b) => a + b,
-      },
-    }),
-    {
-      a: 'a',
-      b: 'b',
-      c: 3,
-      d: 'd',
-      e: 'e',
-    },
-  );
-});
-
-test('reduceConfigsAsyncWithContext should support async functions in array', async () => {
+test('reduceConfigsWithContext should support functions with context', async () => {
   const initial = { a: 'a' };
 
   const config = [
@@ -143,7 +121,7 @@ test('reduceConfigsAsyncWithContext should support async functions in array', as
   ];
 
   assert.deepStrictEqual(
-    await reduceConfigsAsyncWithContext({
+    await reduceConfigsWithContext({
       initial,
       config,
       ctx: {
@@ -160,7 +138,7 @@ test('reduceConfigsAsyncWithContext should support async functions in array', as
   );
 });
 
-test('reduceConfigsAsyncWithContext should support multiple async functions in array', async () => {
+test('reduceConfigsWithContext should support multiple async functions in array', async () => {
   const initial = { value: 1 };
 
   const config = [
@@ -169,7 +147,7 @@ test('reduceConfigsAsyncWithContext should support multiple async functions in a
   ];
 
   assert.deepStrictEqual(
-    await reduceConfigsAsyncWithContext({
+    await reduceConfigsWithContext({
       initial,
       config,
     }),
@@ -177,21 +155,54 @@ test('reduceConfigsAsyncWithContext should support multiple async functions in a
   );
 });
 
-test('reduceConfigsAsyncWithContext should handle single async function', async () => {
+test('reduceConfigsWithMergedContext should support function and merged context', async () => {
+  const initial = { a: 'a' };
+
+  const config = [
+    { b: 'b' },
+    async ({ value, add }) => {
+      value.c = await add(1, 2);
+    },
+    ({ value }) => ({
+      ...value,
+      d: 'd',
+    }),
+    { e: 'e' },
+  ];
+
+  assert.deepStrictEqual(
+    await reduceConfigsWithMergedContext({
+      initial,
+      config,
+      ctx: {
+        add: async (a, b) => a + b,
+      },
+    }),
+    {
+      a: 'a',
+      b: 'b',
+      c: 3,
+      d: 'd',
+      e: 'e',
+    },
+  );
+});
+
+test('reduceConfigsWithMergedContext should handle single async function', async () => {
   const initial = { a: 1 };
 
   assert.deepStrictEqual(
-    await reduceConfigsAsyncWithContext({
+    await reduceConfigsWithMergedContext({
       initial,
-      config: async (o) => ({ ...o, b: 2 }),
+      config: async ({ value }) => ({ ...value, b: 2 }),
     }),
     { a: 1, b: 2 },
   );
 });
 
-test('reduceConfigs should allow false as config', () => {
+test('reduceConfigs should allow false as config', async () => {
   assert.strictEqual(
-    reduceConfigs({
+    await reduceConfigs({
       initial: 'head',
       config: false,
     }),
@@ -199,7 +210,7 @@ test('reduceConfigs should allow false as config', () => {
   );
 
   assert.strictEqual(
-    reduceConfigs({
+    await reduceConfigs({
       initial: 'head',
       config: () => false,
     }),
@@ -207,9 +218,9 @@ test('reduceConfigs should allow false as config', () => {
   );
 
   assert.strictEqual(
-    reduceConfigs({
+    await reduceConfigs({
       initial: 'head',
-      config: ['head', 'head', () => false],
+      config: ['head', 'head', async () => false],
     }),
     false,
   );


### PR DESCRIPTION
## Summary

This PR simplifies reduce-configs for the next major version by making the remaining reducer APIs async and removing the older sync/async split. It keeps `reduceConfigs`, `reduceConfigsWithContext`, and `reduceConfigsWithMergedContext`, all returning `Promise<T>`, while config callbacks may still return sync values, `void`, or promises.

## Breaking Changes

- `reduceConfigs` and `reduceConfigsWithContext` now return `Promise<T>`.
- `reduceConfigsAsyncWithContext`, `reduceConfigsMergeContext`, and related types are no longer exported.