### PR TITLE
feat!: drop CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
       "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,8 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    { syntax: 'es2021', dts: true },
-    { format: 'cjs', syntax: 'es2021' },
-  ],
+  lib: [{ format: 'esm', syntax: 'es2023', dts: true }],
 });

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [{ format: 'esm', syntax: 'es2023', dts: true }],
+  lib: [{ syntax: 'es2023', dts: true }],
 });


### PR DESCRIPTION
## Summary

This PR makes `reduce-configs` ESM-only by removing the CommonJS export condition, CJS build output, and legacy `main` / `module` package fields. It publishes the ESM entry through the `default` export condition and raises the Rslib syntax target to ES2023.

This is a breaking change for consumers that depend on a dedicated CommonJS artifact, `require` export condition, or legacy package entry fields.

## Validation

- `pnpm run build`
- `pnpm run test`
- `pnpm run lint`
- package self-reference import probe