### PR TITLE
chore: remove simple-git-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,9 @@
     "dev": "rslib -w",
     "lint": "rslint && prettier -c .",
     "lint:write": "rslint --fix && prettier -w .",
-    "prepare": "simple-git-hooks && pnpm run build",
+    "prepare": "pnpm run build",
     "test": "rstest",
     "bump": "npx bumpp"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "pnpm run lint:write"
   },
   "devDependencies": {
     "@rslib/core": "^0.21.5",
@@ -35,7 +32,6 @@
     "@rstest/core": "0.10.2",
     "@types/node": "^24.12.4",
     "prettier": "^3.8.3",
-    "simple-git-hooks": "^2.13.1",
     "typescript": "6.0.3"
   },
   "packageManager": "pnpm@11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
-      simple-git-hooks:
-        specifier: ^2.13.1
-        version: 2.13.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -305,10 +302,6 @@ packages:
       typescript:
         optional: true
 
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -533,8 +526,6 @@ snapshots:
       '@rsbuild/core': 2.0.6
     optionalDependencies:
       typescript: 6.0.3
-
-  simple-git-hooks@2.13.1: {}
 
   tinyglobby@0.2.15:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 allowBuilds:
   core-js: false
-  simple-git-hooks: false


### PR DESCRIPTION
## Summary

This PR removes the `simple-git-hooks` setup so package installation no longer configures the pre-commit hook. The `prepare` script now only builds the package, and the pnpm workspace and lockfile no longer reference `simple-git-hooks`.

## Validation

- `pnpm run build`