### PR TITLE
chore(ci): remove unnecessary Playwright install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           run_install: true
 
-      - name: Install Playwright
-        run: npx playwright install
-
       - name: Build Packages
         run: pnpm build
 


### PR DESCRIPTION
This PR removes an unused Playwright browser installation step from CI because the workflow does not run browser-based tests. This avoids downloading browser binaries during every CI run.