### PR TITLE
chore(vscode): use Rstack extension as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["rstack.rslint"]
+  "recommendations": ["rstack.rstack"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,7 @@
   "[javascript]": {
     "editor.defaultFormatter": "rstack.rstack"
   },
-  "[mdx]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
   "[json]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
-  "[jsonc]": {
     "editor.defaultFormatter": "rstack.rstack"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,20 @@
 {
   "search.useIgnoreFiles": true,
-  "cSpell.words": ["rslint", "rstack"]
+  "cSpell.words": ["rslint", "rstack"],
+  "editor.defaultFormatter": "rstack.rstack",
+  "[typescript]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[mdx]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  }
 }


### PR DESCRIPTION
## Summary

This aligns the repository's VS Code setup with the Rstack CLI formatter integration. It recommends `rstack.rstack`, sets it as the workspace default formatter, and adds language-specific overrides for TypeScript, JavaScript, and JSON. The changed files pass `pnpm exec rs fmt --check .vscode/extensions.json .vscode/settings.json`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/378